### PR TITLE
Add hashid support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,9 @@ gem "pagy"
 # Soft delete support
 gem "discard"
 
+# HashID support for obfuscating record IDs
+gem "hashid-rails"
+
 # Error tracking
 gem "sentry-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,10 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashid-rails (1.4.1)
+      activerecord (>= 4.0)
+      hashids (~> 1.0)
+    hashids (1.0.6)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
@@ -355,6 +359,7 @@ DEPENDENCIES
   discard
   factory_bot_rails
   faker
+  hashid-rails
   kamal
   pagy
   pg (~> 1.0)

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,6 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  # Generate and resolve HashIDs for all models inheriting from ApplicationRecord
+  include Hashid::Rails
 end

--- a/config/initializers/0_constants.rb
+++ b/config/initializers/0_constants.rb
@@ -1,6 +1,9 @@
 # Application constants
 APP_NAME = "RapidRails"
 
+# Salt used to generate HashIDs
+HASHID_SALT = ENV.fetch('HASHID_SALT', '618667bffe402a61')
+
 HOST = "rapidrails.dev"
 BASE_URL = "https://#{HOST}"
 

--- a/config/initializers/hashid.rb
+++ b/config/initializers/hashid.rb
@@ -1,0 +1,5 @@
+Hashid::Rails.configure do |config|
+  # Configure the salt for Hashids. Override with HASHID_SALT env var.
+  config.salt = HASHID_SALT
+  config.min_hash_length = 8
+end

--- a/spec/models/metadata_spec.rb
+++ b/spec/models/metadata_spec.rb
@@ -36,4 +36,13 @@ RSpec.describe Metadata, type: :model do
       expect(metadata.discarded_at).not_to be_nil
     end
   end
+
+  describe 'hashid' do
+    it 'uses hashid in to_param and find' do
+      metadata = create(:metadata)
+      hashid = metadata.to_param
+      expect(hashid).to eq(metadata.hashid)
+      expect(Metadata.find(hashid)).to eq(metadata)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- add `hashid-rails` gem
- enable Hashid support on models via `ApplicationRecord`
- configure default Hashid settings
- test hashid behavior for `Metadata`
- define `HASHID_SALT` constant and use it in initializer

## Testing
- `bundle exec rspec spec/models/metadata_spec.rb` *(fails: connection to server at "127.0.0.1" failed)*


------
https://chatgpt.com/codex/tasks/task_e_684cd143f8f08327b0f74a49335cba69